### PR TITLE
version 0.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@roit/roit-response-handler",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "main": "dist/index.js",
   "types": "src/index.ts",
   "repository": "github:roitinnovation/roit-response-handler",
@@ -20,7 +20,7 @@
     "@typescript-eslint/parser": "2.25.0",
     "eslint": "6.8.0",
     "eslint-plugin-import": "2.20.1",
-    "typescript": "3.8.3",
+    "typescript": "4.4.4",
     "ts-node": "8.3.0",
     "chai": "4.2.0",
     "mocha": "6.2.0"

--- a/src/SwaggerResponse.ts
+++ b/src/SwaggerResponse.ts
@@ -1,9 +1,18 @@
 import { applyDecorators } from '@nestjs/common'
-import { ApiOkResponse, getSchemaPath } from '@nestjs/swagger'
+import { ApiExtraModels, ApiResponse, getSchemaPath } from '@nestjs/swagger'
 
-export const SwaggerResponse = (model: string | Function): MethodDecorator =>
+interface Props {
+    type: Function
+    statusCode?: number
+}
+
+export const SwaggerResponse = ({
+    type, statusCode
+}: Props): MethodDecorator =>
     applyDecorators(
-        ApiOkResponse({
+        ApiExtraModels(type),
+        ApiResponse({
+            status: statusCode || 200,
             schema: {
                 properties: {
                     timestamp: {
@@ -15,7 +24,7 @@ export const SwaggerResponse = (model: string | Function): MethodDecorator =>
                     message: {
                         type: 'string'
                     },
-                    data: { $ref: getSchemaPath(model) }
+                    data: { $ref: getSchemaPath(type) }
                 }
             }
         })


### PR DESCRIPTION
Changes:

- Use ApiResponse instead of ApiOkResponse.
- Improved parameter types.


Before:
```js
@SwaggerResponse(MyDTO)
```

After:
```js
@SwaggerResponse({ type: MyDTO, statusCode: 200 })
```